### PR TITLE
config: Remove hold_current from generic-th3d-ezboard-lite-v2.0.cfg

### DIFF
--- a/config/generic-th3d-ezboard-lite-v2.0.cfg
+++ b/config/generic-th3d-ezboard-lite-v2.0.cfg
@@ -91,7 +91,6 @@ max_temp: 250
 uart_pin: PC11
 tx_pin: PC10
 run_current: 0.800
-hold_current: 0.700
 stealthchop_threshold: 999999
 uart_address: 3
 


### PR DESCRIPTION
We no longer recommend setting a hold_current.

Signed-off-by: Kevin O'Connor <kevin@koconnor.net>